### PR TITLE
Upgrade to version v1.4.2

### DIFF
--- a/source/cdk_solution_helper_py/helpers_cdk/aws_solutions/cdk/aws_lambda/cfn_custom_resources/solutions_metrics/src/custom_resources/requirements.txt
+++ b/source/cdk_solution_helper_py/helpers_cdk/aws_solutions/cdk/aws_lambda/cfn_custom_resources/solutions_metrics/src/custom_resources/requirements.txt
@@ -1,2 +1,3 @@
 requests==2.31.0
+urllib3==1.26.16
 crhelper==2.0.11


### PR DESCRIPTION
### Changed

- Upgraded requests to 2.31.0 that addresses the [unintended leak of proxy-authorization header in requests](https://github.com/advisories/GHSA-j8r2-6x86-q33q)
- Added supporting library (`urllib3`)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
